### PR TITLE
Reconciling differences between latest tutorial version and git version

### DIFF
--- a/CCColor.tcl
+++ b/CCColor.tcl
@@ -16,7 +16,7 @@ proc cccolor {args} \
 #####################
 # input files
 ####################
-proc ::CCColor::cccolor {MOL mapname resolution threshold spacing cutoff ss_on res_on gen_sel res_sel {bb_only 0} args} {
+proc ::CCColor::cccolor {MOL mapname resolution threshold spacing cutoff ss_on res_on gen_sel res_sel {tempfolder "/usr/tmp"} {bb_only 0} args} {
 	#################
 	# Program settings
 	#################
@@ -41,7 +41,8 @@ proc ::CCColor::cccolor {MOL mapname resolution threshold spacing cutoff ss_on r
 	set dens_mol [mol new $mapname.dx]
 
 	#source getSS.tcl
-	getSS $MOL.ss $pdb segname /usr/tmp
+	
+	getSS $MOL.ss $pdb segname $tempfolder
 	assignSS $MOL.ss $pdb segname
 
 	set chains [lindex [list [lsort -unique [$atomSel get fragment]]] 0]
@@ -75,8 +76,8 @@ proc ::CCColor::cccolor {MOL mapname resolution threshold spacing cutoff ss_on r
 					puts $log [$ssSel num]
 					#    volmap mask $ssSel -o mask.dx -cutoff $cutoff
 					#   volutil -mult ${emdbName}_density.dx mask.dx -o compare.dx
-					#    set CCSS [mdff ccc $ssSel -i $dens_mol -res $resolution -spacing $spacing]
-					set CCSS [mdffi cc $ssSel -mol $dens_mol -res $resolution -spacing $spacing -thresholddensity $threshold]
+					set CCSS [mdff ccc $ssSel -i $mapname.dx -res $resolution -spacing $spacing -thresholddensity $threshold]
+					# set CCSS [mdffi cc $ssSel -mol $dens_mol -res $resolution -spacing $spacing -thresholddensity $threshold]
 					#set CCSS 0.0
 					set str [string range "$CCSS" 1 3]
 					if {[string equal $str "nan"] || [string equal $str "NaN"]} {
@@ -113,7 +114,8 @@ proc ::CCColor::cccolor {MOL mapname resolution threshold spacing cutoff ss_on r
 
 						#volmap mask $resSel -o mask.dx -cutoff $cutoff
 						#volutil -mult ${emdbName}_density.dx mask.dx -o compare.dx
-						set CCres [mdffi cc $resSel -mol $dens_mol -res $resolution -spacing $spacing -thresholddensity $threshold]
+						set CCres [mdff ccc $resSel -i $mapname.dx -res $resolution -spacing $spacing -thresholddensity $threshold]
+						# set CCres [mdffi cc $resSel -mol $dens_mol -res $resolution -spacing $spacing -thresholddensity $threshold]
 						set str [string range "$CCres" 1 3]
 						if {[string equal $str "nan"] || [string equal $str "NaN"]} {
 							$resSel set beta -1.0

--- a/check_clusterjob.tcl
+++ b/check_clusterjob.tcl
@@ -34,6 +34,9 @@ proc ::CheckCluster::check_clusterjob {uname jobid ntasks} \
 				switch -exact -- $status {
 					"r" {
 						lappend running_jobs [lindex $line 2]
+					}	
+					"t" {
+						lappend running_jobs [lindex $line 2]
 					}
 					"qw" {
 						set inf [lindex $line 2]

--- a/find_selection.tcl
+++ b/find_selection.tcl
@@ -185,6 +185,10 @@ proc ::FindSelection::find_selection {MOL selections config {offset 4} args} \
 	mol delete $searchmol
 	close $out_ros
 	puts "finished finding selections."
+	set lastchar [string range $exclude_string end end]
+	if {$lastchar == ","} {
+		return [list $out_spans [string range $exclude_string 0 [expr [string length $exclude_string]-2]] $chain_config $constraint]
+	}
 	return [list $out_spans $exclude_string $chain_config $constraint]
 	#return [list $out_spans [string range $exclude_string 0 [expr [string length $exclude_string]-2]] $chain_config $constraint]
 #  return [list $out_spans [string range $exclude_string 0 [expr $end-1]] $chain_config $constraint]

--- a/find_selection.tcl
+++ b/find_selection.tcl
@@ -16,13 +16,13 @@ proc find_selection {args} \
 #config should contain bb and chi settings for span for each selection, such as [list {0 1} {1 1}]
 # first: chi, second: bb
 proc ::FindSelection::find_selection {MOL selections config {offset 4} args} \
-{	
+{
 	puts "Trying to find selections."
 	puts $selections
 	set seltexts []
 	foreach seltext $selections {
-		lappend seltexts $seltext	
-	}	
+		lappend seltexts $seltext
+	}
 	set searchmol [mol new $MOL.pdb]
 
 	set final_spans []
@@ -32,7 +32,7 @@ proc ::FindSelection::find_selection {MOL selections config {offset 4} args} \
 		set vmd_resids [lsort -unique -integer [$searchsel get residue]]
 		set ros_resids []
 		foreach vmd_resid $vmd_resids {
-			lappend ros_resids [expr $vmd_resid +1]	
+			lappend ros_resids [expr $vmd_resid +1]
 		}
 		set counter -1
 		set span_closed 1
@@ -50,8 +50,8 @@ proc ::FindSelection::find_selection {MOL selections config {offset 4} args} \
 				set current_span []
 				set counter [lindex $ros_resids $i]
 				lappend current_span $counter
-			} 
-	
+			}
+
 			if {$i == [expr [llength $ros_resids] -1]} {
 				lappend current_span $counter
 				lappend all_spans $current_span
@@ -63,7 +63,7 @@ proc ::FindSelection::find_selection {MOL selections config {offset 4} args} \
 		}
 		lappend final_spans $all_spans
 	}
-	
+
 	set out_ros [open "$MOL-spans.txt" w]
 	set span_config []
 	set single_spans []
@@ -135,9 +135,9 @@ proc ::FindSelection::find_selection {MOL selections config {offset 4} args} \
 			} else {
 				append exclude_string "$current_start-$i"
 			}
-			
+
 			# puts "$current_start-$i"
-		} 
+		}
 	}
 
 	set current_start 1
@@ -171,7 +171,7 @@ proc ::FindSelection::find_selection {MOL selections config {offset 4} args} \
 		if {$i == $tot_resnum && $i != $before_end} {
 			append constraint "{$current_start $i}"
 			# puts "$current_start-$i"
-		} 
+		}
 	}
 
 
@@ -185,5 +185,5 @@ proc ::FindSelection::find_selection {MOL selections config {offset 4} args} \
 	mol delete $searchmol
 	close $out_ros
 	puts "finished finding selections."
-	return [list $out_spans $exclude_string $chain_config $constraint]
+  return [list $out_spans [string range $exclude_string 0 [expr $end-1]] $chain_config $constraint]
 }

--- a/find_selection.tcl
+++ b/find_selection.tcl
@@ -185,6 +185,7 @@ proc ::FindSelection::find_selection {MOL selections config {offset 4} args} \
 	mol delete $searchmol
 	close $out_ros
 	puts "finished finding selections."
-#	return [list $out_spans [string range $exclude_string 0 [expr [string length $exclude_string]-2]] $chain_config $constraint]
-  return [list $out_spans [string range $exclude_string 0 [expr $end-1]] $chain_config $constraint]
+	return [list $out_spans $exclude_string $chain_config $constraint]
+	#return [list $out_spans [string range $exclude_string 0 [expr [string length $exclude_string]-2]] $chain_config $constraint]
+#  return [list $out_spans [string range $exclude_string 0 [expr $end-1]] $chain_config $constraint]
 }

--- a/find_selection.tcl
+++ b/find_selection.tcl
@@ -185,5 +185,6 @@ proc ::FindSelection::find_selection {MOL selections config {offset 4} args} \
 	mol delete $searchmol
 	close $out_ros
 	puts "finished finding selections."
-	return [list $out_spans [string range $exclude_string 0 [expr [string length $exclude_string]-2]] $chain_config $constraint]
+#	return [list $out_spans [string range $exclude_string 0 [expr [string length $exclude_string]-2]] $chain_config $constraint]
+  return [list $out_spans [string range $exclude_string 0 [expr $end-1]] $chain_config $constraint]
 }

--- a/find_selection.tcl
+++ b/find_selection.tcl
@@ -16,13 +16,13 @@ proc find_selection {args} \
 #config should contain bb and chi settings for span for each selection, such as [list {0 1} {1 1}]
 # first: chi, second: bb
 proc ::FindSelection::find_selection {MOL selections config {offset 4} args} \
-{
+{	
 	puts "Trying to find selections."
 	puts $selections
 	set seltexts []
 	foreach seltext $selections {
-		lappend seltexts $seltext
-	}
+		lappend seltexts $seltext	
+	}	
 	set searchmol [mol new $MOL.pdb]
 
 	set final_spans []
@@ -32,7 +32,7 @@ proc ::FindSelection::find_selection {MOL selections config {offset 4} args} \
 		set vmd_resids [lsort -unique -integer [$searchsel get residue]]
 		set ros_resids []
 		foreach vmd_resid $vmd_resids {
-			lappend ros_resids [expr $vmd_resid +1]
+			lappend ros_resids [expr $vmd_resid +1]	
 		}
 		set counter -1
 		set span_closed 1
@@ -50,8 +50,8 @@ proc ::FindSelection::find_selection {MOL selections config {offset 4} args} \
 				set current_span []
 				set counter [lindex $ros_resids $i]
 				lappend current_span $counter
-			}
-
+			} 
+	
 			if {$i == [expr [llength $ros_resids] -1]} {
 				lappend current_span $counter
 				lappend all_spans $current_span
@@ -63,7 +63,7 @@ proc ::FindSelection::find_selection {MOL selections config {offset 4} args} \
 		}
 		lappend final_spans $all_spans
 	}
-
+	
 	set out_ros [open "$MOL-spans.txt" w]
 	set span_config []
 	set single_spans []
@@ -135,9 +135,9 @@ proc ::FindSelection::find_selection {MOL selections config {offset 4} args} \
 			} else {
 				append exclude_string "$current_start-$i"
 			}
-
+			
 			# puts "$current_start-$i"
-		}
+		} 
 	}
 
 	set current_start 1
@@ -171,7 +171,7 @@ proc ::FindSelection::find_selection {MOL selections config {offset 4} args} \
 		if {$i == $tot_resnum && $i != $before_end} {
 			append constraint "{$current_start $i}"
 			# puts "$current_start-$i"
-		}
+		} 
 	}
 
 
@@ -185,5 +185,5 @@ proc ::FindSelection::find_selection {MOL selections config {offset 4} args} \
 	mol delete $searchmol
 	close $out_ros
 	puts "finished finding selections."
-	return [list $out_spans [string range $exclude_string 0 [expr $end-1]] $chain_config $constraint]
+	return [list $out_spans $exclude_string $chain_config $constraint]
 }

--- a/modelmaker.tcl
+++ b/modelmaker.tcl
@@ -27,11 +27,11 @@ namespace eval ::MODELMAKER {
   #or gui, if not present, perhaps pop up a dialog with a Browse button to allow user to get the path and
   #proceed...
   if {[info exists env(ROSETTADB)]} {
-    variable rosettadbpath $env(ROSETTADB) 
+    variable rosettadbpath $env(ROSETTADB)
   } else {
-    variable rosettadbpath "" 
+    variable rosettadbpath ""
   }
- 
+
   #currently set in .vmdrc like ROSETTADB, !!HOWEVER!!
   #this should not be necessary to specify if we tell the user that
   #the rosetta bin directory is on their PATH. Just setting this variable
@@ -40,9 +40,9 @@ namespace eval ::MODELMAKER {
   #single "ROSETTAPATH" variable that just points to where the user installed rosetta's
   #top level directory. Then we can just use that and append the bin/ and database/ locations as needed.
   if {[info exists env(ROSETTAPATH)]} {
-    variable rosettaPath $env(ROSETTAPATH) 
+    variable rosettaPath $env(ROSETTAPATH)
   } else {
-    variable rosettaPath "" 
+    variable rosettaPath ""
   }
  # variable defaultGapfindMol "top"
   variable DefaultNStruct 5000
@@ -138,7 +138,7 @@ proc ::MODELMAKER::insertion { args } {
 #for testing.
   #set tempPath [pwd]/full_length_model
   #set tempdir [pwd]/full_length_model
- 
+
   set rosettapath $rosettaPath
   set rosettaDBpath $rosettadbpath
   set platform $rosettaEXE
@@ -164,27 +164,27 @@ proc ::MODELMAKER::insertion { args } {
   if { [info exists arg(model)] } {
     #set model $arg(model)
   #NOTE: Right now, because of RosettaVMD package, this needs to be the pdb name without the .pdb
-  #extension. Need to change RosettaVMD to not require this. 
+  #extension. Need to change RosettaVMD to not require this.
     set model [string range $arg(model) 0 [expr [string last ".pdb" $arg(model)] - 1 ]]
   } else {
     error "A full model pdb file must be specified!"
   }
-  
+
   if { [info exists arg(sel)] } {
     set sel [list $arg(sel)]
   } else {
     error "An atomselection text must be specified!"
   }
-  
+
   if { [info exists arg(fragfiles)] } {
     set fragfiles $arg(fragfiles)
   } else {
     error "At least one fragment file must be specified!"
   }
-  
+
   if { [info exists arg(fasta)] } {
   #NOTE: Right now, because of RosettaVMD package, this needs to be the fasta name without the .fasta
-  #extension. Need to change RosettaVMD to not require this. 
+  #extension. Need to change RosettaVMD to not require this.
     set fasta [string range $arg(fasta) 0 [expr [string last ".fasta" $arg(fasta)] - 1 ]]
   #  set fasta $arg(fasta)
   } else {
@@ -209,7 +209,7 @@ proc ::MODELMAKER::insertion { args } {
   } else {
     set nstruct $DefaultNStruct
   }
-  
+
   if { [info exists arg(jobname)] } {
     set jobname $arg(jobname)
   } else {
@@ -218,7 +218,7 @@ proc ::MODELMAKER::insertion { args } {
 
   set modelPath [file dirname $arg(model)]
   if { $modelPath == "." } {
-    set tempPath [pwd]  
+    set tempPath [pwd]
   } else {
     set tempPath $modelPath
   }
@@ -227,7 +227,7 @@ proc ::MODELMAKER::insertion { args } {
   set temp_mol [mol new $arg(model)]
   set temp_sel [atomselect $temp_mol all]
   set resstart [lindex [lsort -integer [$temp_sel get resid]] 0]
-   
+
   foreach pdb [glob "rosetta_output_$jobname/pdb_out/*"] {
     set full_mol [mol new $pdb]
     set full_sel [atomselect $full_mol all]
@@ -257,7 +257,7 @@ proc ::MODELMAKER::abinitio_usage { } {
 }
 
 proc ::MODELMAKER::abinitio { args } {
-  
+
   variable rosettaEXE
   variable rosettadbpath
   variable DefaultNStruct
@@ -284,7 +284,7 @@ proc ::MODELMAKER::abinitio { args } {
 #for testing.
   #set tempPath [pwd]/full_length_model
   #set tempdir [pwd]/full_length_model
- 
+
   set rosettapath $rosettaPath
   set rosettaDBpath $rosettadbpath
   set platform $rosettaEXE
@@ -313,24 +313,24 @@ proc ::MODELMAKER::abinitio { args } {
   if { [info exists arg(model)] } {
     #set model $arg(model)
   #NOTE: Right now, because of RosettaVMD package, this needs to be the pdb name without the .pdb
-  #extension. Need to change RosettaVMD to not require this. 
+  #extension. Need to change RosettaVMD to not require this.
     set model [string range $arg(model) 0 [expr [string last ".pdb" $arg(model)] - 1 ]]
   } else {
     error "A full model pdb file must be specified!"
   }
-  
+
   if { [info exists arg(sel)] } {
     set sel [list $arg(sel)]
   } else {
     error "An atomselection text must be specified!"
   }
-  
+
   if { [info exists arg(anchor)] } {
     set anchor $arg(anchor)
   } else {
     error "An anchor residue id must be specified!"
   }
-  
+
   if { [info exists arg(fragfiles)] } {
     set fragfiles $arg(fragfiles)
   } else {
@@ -355,25 +355,25 @@ proc ::MODELMAKER::abinitio { args } {
   } else {
     set nstruct $DefaultNStruct
   }
-  
+
   if { [info exists arg(cluster)] } {
     set cluster $arg(cluster)
   } else {
     set cluster $DefaultCluster
   }
-  
+
   if { [info exists arg(npertask)] } {
     set npertask $arg(npertask)
   } else {
     set npertask $DefaultNPerTask
   }
-  
+
   if { [info exists arg(testrun)] } {
     set testrun $arg(testrun)
   } else {
     set testrun $DefaultTestRun
   }
-  
+
   if { [info exists arg(jobname)] } {
     set jobname $arg(jobname)
   } else {
@@ -382,7 +382,7 @@ proc ::MODELMAKER::abinitio { args } {
 
   set modelPath [file dirname $arg(model)]
   if { $modelPath == "." } {
-    set tempPath [pwd]  
+    set tempPath [pwd]
   } else {
     set tempPath $modelPath
   }
@@ -438,10 +438,10 @@ proc ::MODELMAKER::analyze { args } {
     }
   }
 
-  puts $arg(model)  
+  puts $arg(model)
   if { [info exists arg(model)] } {
   #NOTE: Right now, because of RosettaVMD package, this needs to be the pdb name without the .pdb
-  #extension. Need to change RosettaVMD to not require this. 
+  #extension. Need to change RosettaVMD to not require this.
     set model [string range $arg(model) 0 [expr [string last ".pdb" $arg(model)] - 1 ]]
   } else {
     error "A full model pdb file must be specified!"
@@ -452,7 +452,7 @@ proc ::MODELMAKER::analyze { args } {
   } else {
     error "Number of structures to analyze must be specified!"
   }
-  
+
 #This is pretty cumbersome for the user and fairly opaque. Will have to find a succinct way of listing the
 #possibilities and summarizing functionality in the usage command...
  #Also, like fragment files, is a list of lists so the user will have to do somehing like
@@ -462,25 +462,25 @@ proc ::MODELMAKER::analyze { args } {
   } else {
     error "Analysis tasks must be specified!"
   }
-  
+
   if { [info exists arg(align_template)] } {
     set align_template $arg(align_template)
   } else {
     set align_template "$DefaultAlignTemplate"
   }
-  
+
   if { [info exists arg(align_rosetta)] } {
     set align_rosetta $arg(align_rosetta)
   } else {
     set align_rosetta $align_template
   }
-  
+
   if { [info exists arg(bestN)] } {
     set bestN $arg(bestN)
   } else {
     set bestN $nstruct
   }
-  
+
   if { [info exists arg(jobname)] } {
     set jobname $arg(jobname)
   } else {
@@ -492,13 +492,13 @@ proc ::MODELMAKER::analyze { args } {
   } else {
     set insertion $DefaultInsertion
   }
-  
+
   if { [info exists arg(cluster)] } {
     set cluster $arg(cluster)
   } else {
     set cluster $DefaultCluster
   }
- 
+
  #These need to be changed in the underlying package to refer to the variable instead.
 #e.g., $::MODELMAKER::rosettaDBpath
 #instead of using these 'global' variables which gets confusing and dangerous.
@@ -509,7 +509,7 @@ proc ::MODELMAKER::analyze { args } {
  global platform
 
  global packagePath
- global vmdexe 
+ global vmdexe
 #can we avoid this or make it optional?
  global gnuplotexe
 
@@ -524,11 +524,11 @@ proc ::MODELMAKER::analyze { args } {
   #If you want to use a different template for alignment, why just a different dir? What does the filename have to be?
 #why must this be set regardless?
   set tempdir [pwd]/full_length_model
- 
+
   set rosettapath $rosettaPath
   set rosettaDBpath $rosettadbpath
   set platform $rosettaEXE
-  
+
   set packagePath $::env(RosettaVMDDIR)
 
 #assumes in PATH which should be reasonable
@@ -538,12 +538,12 @@ proc ::MODELMAKER::analyze { args } {
   switch $insertion {
     "yes" {
       set modelname "$model\_S"
-      set insert_model $model 
+      set insert_model $model
     }
-    "no"  { 
+    "no"  {
       set modelname $model
-      set insert_model "" 
-    }  
+      set insert_model ""
+    }
   }
   puts "MODEL: $model  INSERT_MODEL: $insert_model"
   #jobname mol bestN nstruct cluster align_template align_rosetta analysis_components
@@ -567,7 +567,7 @@ proc ::MODELMAKER::renumber { sel start } {
 
 proc ::MODELMAKER::full_length_model_usage { } {
   variable DefaultResStart
-  
+
   puts "Usage: modelmaker full_length_model -template <template pdb> -fragfiles <list of fragment files> \
     -fasta <fasta file> ?options?"
   puts "Options:"
@@ -596,19 +596,19 @@ proc ::MODELMAKER::full_length_model { args } {
       #-output { set arg(output) $val }
     }
   }
-  
+
   if { [info exists arg(template)] } {
     set template $arg(template)
   } else {
     error "A template pdb file must be specified!"
   }
-  
+
   if { [info exists arg(fragfiles)] } {
     set fragfiles $arg(fragfiles)
   } else {
     error "A list of two fragment files must be specified!"
   }
-  
+
   if { [info exists arg(fasta)] } {
     set fasta $arg(fasta)
   } else {
@@ -620,22 +620,22 @@ proc ::MODELMAKER::full_length_model { args } {
   #} else {
   #  error "A model name must be specified!"
   #}
-  
+
   if { [info exists arg(resstart)] } {
     set resstart $arg(resstart)
   } else {
     set resstart $DefaultResStart
   }
-  
+
 #  if { [info exists arg(output)] } {
 #    set output $arg(output)
 #  } else {
 #    #this mimics the default rosetta behaviour
 #    set output $template
 #  }
-  
-  
- 
+
+
+
   #this assume only 9 and 3 length fragment files and in a specific order. Can
   #we implement some logic to look at the provided files and determine what all we have?
   exec full_length_model.$rosettaEXE -in:file:fasta $fasta \
@@ -643,8 +643,8 @@ proc ::MODELMAKER::full_length_model { args } {
     -loops:frag_sizes 9 3 1 \
     -in:file::s $template \
     -overwrite
- 
-  
+
+
   set full_mol [mol new ${template}_full_length.pdb]
   set full_sel [atomselect $full_mol all]
   renumber $full_sel $resstart
@@ -658,7 +658,7 @@ proc ::MODELMAKER::full_length_model { args } {
 
 
 proc ::MODELMAKER::gapfind_usage { } {
-  
+
   variable defaultGapfindSel
  # variable defaultGapfindMol
 
@@ -668,7 +668,7 @@ proc ::MODELMAKER::gapfind_usage { } {
   puts "  -sel <atom selection> (default: $defaultGapfindSel)"
   #puts "  -mol <molid> (find gaps in already loaded molecule) (default: $defaultGapfindMol)"
   puts "  -mol <molid> (find gaps in already loaded molecule)"
-  
+
 }
 
 
@@ -677,7 +677,7 @@ proc ::MODELMAKER::gapfind { args } {
 
   variable defaultGapfindSel
  # variable defaultGapfindMol
-  
+
   set nargs [llength [lindex $args 0]]
   if {$nargs == 0} {
     gapfind_usage
@@ -688,7 +688,7 @@ proc ::MODELMAKER::gapfind { args } {
 
 #  mol delete all
 #  mol new $MOL.pdb
-  
+
   foreach {name val} $args {
     switch -- $name {
       -i { set arg(i) $val }
@@ -702,19 +702,19 @@ proc ::MODELMAKER::gapfind { args } {
   } elseif { ![info exists arg(i)] && ![info exists arg(mol)] } {
     error "either an input pdb OR a mol id must be specified"
   }
-  
+
   if { [info exists arg(i)] } {
     set inputpdb $arg(i)
   } else {
     set inputpdb ""
   }
-  
+
   if { [info exists arg(sel)] } {
     set inputsel $arg(sel)
   } else {
     set inputsel $defaultGapfindSel
   }
-  
+
   if { [info exists arg(mol)] } {
     set inputmol $arg(mol)
   } else {
@@ -727,7 +727,7 @@ proc ::MODELMAKER::gapfind { args } {
   } else {
     set MOLID [molinfo $inputmol get id]
   }
-  
+
   set molname [molinfo $MOLID get name]
 
   set chains [lsort -unique [[atomselect $MOLID all] get chain]]
@@ -777,6 +777,3 @@ proc ::MODELMAKER::gapfind { args } {
 #    }
 #    return [ uplevel set $int ]
 #}
-
-
-

--- a/modelmaker.tcl
+++ b/modelmaker.tcl
@@ -13,10 +13,10 @@ namespace eval ::MODELMAKER {
   #best to be independent of any future naming conventions of rosetta. Use wildcard instead?
   switch $tcl_platform(os) {
     "Darwin" {
-      variable rosettaEXE "macos*release"
+      variable rosettaEXE "macosclangrelease"
     }
     "Linux" {
-      variable rosettaEXE "linux*release"
+      variable rosettaEXE "linuxgccrelease"
     }
     default {
       variable rosettaEXE "Unrecognized"

--- a/rosetta_input_generator.tcl
+++ b/rosetta_input_generator.tcl
@@ -995,11 +995,6 @@ $rosettapath/minirosetta.$platform \\
 	-nstruct $nstruct \\
 	-overwrite
 
-mkdir intermediates
-mv loops_closed*.pdb ./intermediates/
-mv *.sc ./sc_out/
-mv $jobname*.pdb ./pdb_out/
-
 "
 }
 
@@ -1095,8 +1090,6 @@ $rosettapath/rosetta_scripts.$platform \\
     -ignore_zero_occupancy false\\
     -overwrite
 
-mv \${JOBNAME}*.pdb ./pdb_out/
-mv *.sc ./sc_out/
 
 "
 }

--- a/rosetta_input_generator.tcl
+++ b/rosetta_input_generator.tcl
@@ -14,13 +14,13 @@
 
 namespace eval ::RosettaInputGenerator {
     namespace export refine_with_rosetta
-    # namespace export refine_sidechains_rosetta
+    namespace export refine_sidechains_rosetta
     namespace export rosetta_abinitio
-
+    
 	# Set up Variable
 	set version 0.1
 	set packageDescription "RosettaInputGenerator Plugin"
-
+ 
     # Variable for the path of the script
     variable home [file join [pwd] [file dirname [info script]]]
 }
@@ -31,10 +31,10 @@ proc refine_with_rosetta {args} \
 	return [eval ::RosettaInputGenerator::refine_with_rosetta $args]
 }
 
-#proc refine_sidechains_rosetta {args} \
-#{
-#	return [eval ::RosettaInputGenerator::refine_sidechains_rosetta $args]
-#}
+proc refine_sidechains_rosetta {args} \
+{
+	return [eval ::RosettaInputGenerator::refine_sidechains_rosetta $args]
+}
 
 proc rosetta_abinitio {args} \
 {
@@ -110,7 +110,7 @@ proc ::RosettaInputGenerator::refine_with_rosetta {jobname MOL mapname res score
 		set cart [::RosettaInputGenerator::make_cart_sample [list cen5_50 $score_dens cen cen dens_soft auto density %%rms%% 200 0 0 25 4 7 25 "$exclude"]]
 		append tot $cart
 	}
-
+	
 	# append tot [::RosettaInputGenerator::make_full_atom_mover "fullatom"]
 
 	# set fr [::RosettaInputGenerator::make_fastrelax relax 1 [list {"Chain" 1 0 0}]]
@@ -119,7 +119,7 @@ proc ::RosettaInputGenerator::refine_with_rosetta {jobname MOL mapname res score
 	set cst [::RosettaInputGenerator::make_coord_cst [list coordcst 20 CA $anchor_residue 0] $conv_anchor_spans]
 	append tot $cst
 
-# "centroid" , "coordcst" "cenmin"
+# "centroid" , "coordcst" "cenmin" 
 	lappend allMovers "setupdens" "loaddens" "coordcst" "relaxcart";#
 	if {$cartesianSampler} {
 		lappend allMovers "coordcst" "cen5_50" "coordcst" "relaxcart";
@@ -158,7 +158,7 @@ proc ::RosettaInputGenerator::refine_with_rosetta {jobname MOL mapname res score
 		puts "Preparing $nstruct structures on cluster. $tasks tasks with $nPerTask structures each."
 		set bashscript [::RosettaInputGenerator::make_cluster_script 25 1.5 $res $mapname.mrc $jobname $nstruct $tasks $nPerTask]
 	}
-
+	
 
 	set script [open "$jobname.sh" w]
 	puts $script $bashscript
@@ -225,7 +225,7 @@ proc ::RosettaInputGenerator::rosetta_basic_refinement {jobname MOL nstruct clus
 		# set cart [::RosettaInputGenerator::make_cart_sample [list cen5_50 $score_dens cen cen dens_soft auto density %%rms%% 200 0 0 25 4 7 25 "$exclude"]]
 		# append tot $cart
 	# }
-
+	
 	# append tot [::RosettaInputGenerator::make_full_atom_mover "fullatom"]
 
 	# set fr [::RosettaInputGenerator::make_fastrelax relax 1 [list {"Chain" 1 0 0}]]
@@ -237,7 +237,7 @@ proc ::RosettaInputGenerator::rosetta_basic_refinement {jobname MOL nstruct clus
 	set fr [make_fastrelax relax 1 $converted]
 	append tot $fr
 
-# "centroid" , "coordcst" "cenmin"
+# "centroid" , "coordcst" "cenmin" 
 	lappend allMovers "coordcst" "relax";#
 
 	append tot "</MOVERS>\n"
@@ -275,7 +275,7 @@ proc ::RosettaInputGenerator::rosetta_basic_refinement {jobname MOL nstruct clus
 		# puts "Preparing $nstruct structures on cluster. $tasks tasks with $nPerTask structures each."
 		# set bashscript [::RosettaInputGenerator::make_cluster_script 25 1.5 $res $mapname.mrc $jobname $nstruct $tasks $nPerTask]
 	}
-
+	
 
 	set script [open "$jobname.sh" w]
 	puts $script $bashscript
@@ -383,7 +383,7 @@ proc ::RosettaInputGenerator::rosetta_basic_refinement {jobname MOL nstruct clus
 # 		puts "Preparing $nstruct structures on cluster. $tasks tasks with $nPerTask structures each."
 # 		set bashscript [make_cluster_script 25 1.5 $res $mapname.mrc $jobname $nstruct $tasks $nPerTask]
 # 	}
-
+	
 
 # 	set script [open "$jobname.sh" w]
 # 	puts $script $bashscript
@@ -430,7 +430,7 @@ proc ::RosettaInputGenerator::rosetta_abinitio {jobname MOL fragfiles fragpath n
 
 	#LOAD SCRFXNS
 	#puts [make_default_scfxn]
-
+	
 	#append tot [make_default_scfxn]
 
 	#RESIDUE SELECTORS
@@ -477,16 +477,16 @@ proc ::RosettaInputGenerator::rosetta_abinitio {jobname MOL fragfiles fragpath n
 
 	#lappend allMovers "coordcst"
 
-
+	
 	#lappend allMovers "relax"
 
-
+	
 	#lappend allMovers "cen5_50"
 
-
+	
 	#lappend allMovers "relaxcart"
 
-
+	
 	#lappend allMovers "cenmin"
 
 	append tot "</MOVERS>\n"
@@ -524,7 +524,7 @@ proc ::RosettaInputGenerator::rosetta_abinitio {jobname MOL fragfiles fragpath n
 	} elseif {!$test && !$cluster} {
 		set bashscript [make_abinitio_local_script $jobname $nstruct]
 	}
-
+	
 
 	set script [open "$jobname.sh" w]
 	puts $script $bashscript
@@ -595,14 +595,14 @@ proc ::RosettaInputGenerator::rosetta_insertion {jobname MOL fragfiles fasta fra
 
 }
 
-#<CartesianSampler name=cen5_50 automode_scorecut=-0.5 scorefxn=cen mcscorefxn=cen
-#fascorefxn=dens_soft strategy="auto" fragbias="density" rms=%%rms%% ncycles=200 fullatom=0
+#<CartesianSampler name=cen5_50 automode_scorecut=-0.5 scorefxn=cen mcscorefxn=cen 
+#fascorefxn=dens_soft strategy="auto" fragbias="density" rms=%%rms%% ncycles=200 fullatom=0 
 #bbmove=0 nminsteps=25 temp=4 fraglens=7 nfrags=25 residues_to_exclude="50-116"/>
 # usage
 
 
 #<Chain number=1 chi=0 bb=0 />
-#<Span begin=1 end=61 chi=1 bb=1 />
+#<Span begin=1 end=61 chi=1 bb=1 /> 
 # <Jump number=1 setting=0/>
 # each component has to be like:
 #
@@ -620,19 +620,19 @@ proc ::RosettaInputGenerator::make_movemap {components} \
 				if {[llength $comp] != 4} {
 					wrong_input "chain length"
 				}
-				append out "<Chain number=\"[lindex $comp 1]\" chi=\"[lindex $comp 2]\" bb=\"[lindex $comp 3]\" /> \n"
+				append out "<Chain number=[lindex $comp 1] chi=[lindex $comp 2] bb=[lindex $comp 3] /> \n"
 			}
 			"Span" {
 				if {[llength $comp] != 5} {
 					wrong_input "span length"
 				}
-				append out "<Span begin=\"[lindex $comp 1]\" end=\"[lindex $comp 2]\" chi=\"[lindex $comp 3]\" bb=\"[lindex $comp 4]\" /> \n"
+				append out "<Span begin=[lindex $comp 1] end=[lindex $comp 2] chi=[lindex $comp 3] bb=[lindex $comp 4] /> \n"
 			}
 			"Jump" {
 				if {[llength $comp] != 3} {
 					wrong_input
 				}
-				append out "<Jump number=\"[lindex $comp 1]\" setting=\"[lindex $comp 2]\" /> \n"
+				append out "<Jump number=[lindex $comp 1] setting=[lindex $comp 2] /> \n"
 			}
 			default {
 				::RosettaInputGenerator::wrong_input
@@ -643,7 +643,7 @@ proc ::RosettaInputGenerator::make_movemap {components} \
 	return $out
 }
 
-#<CoordinateCst name=coordcst stddev=20 atom=CA anchor_res=90 jump=0  >
+#<CoordinateCst name=coordcst stddev=20 atom=CA anchor_res=90 jump=0  > 
 #<Span begin=66 end=104 />
 #</CoordinateCst>
 # usage:
@@ -655,12 +655,12 @@ proc ::RosettaInputGenerator::make_coord_cst {config spans} \
 	if {[llength $config] != 5} {
 		::RosettaInputGenerator::wrong_input
 	}
-	append out "<CoordinateCst name=\"[lindex $config 0]\" stddev=\"[lindex $config 1]\" atom=\"[lindex $config 2]\" anchor_res=\"[lindex $config 3]\" jump=\"[lindex $config 4]\"> \n"
+	append out "<CoordinateCst name=[lindex $config 0] stddev=[lindex $config 1] atom=[lindex $config 2] anchor_res=[lindex $config 3] jump=[lindex $config 4]> \n"
 	foreach span $spans {
 		if {[llength $span] != 2} {
 			::RosettaInputGenerator::wrong_input
 		}
-		append out "<Span begin=\"[lindex $span 0]\" end=\"[lindex $span 1]\" /> \n"
+		append out "<Span begin=[lindex $span 0] end=[lindex $span 1] /> \n"
 	}
 	append out "</CoordinateCst> \n"
 	return $out
@@ -675,7 +675,7 @@ proc ::RosettaInputGenerator::make_coord_cst {config spans} \
 proc ::RosettaInputGenerator::make_fastrelax {name repeats movemap_comps} \
 {
 	set out ""
-	append out "<FastRelax name=\"$name\" repeats=\"$repeats\">\n"
+	append out "<FastRelax name=$name repeats=$repeats>\n"
 	append out [::RosettaInputGenerator::make_movemap $movemap_comps]
 	append out "</FastRelax>\n"
 	return $out
@@ -691,10 +691,10 @@ proc ::RosettaInputGenerator::make_fastrelax {name repeats movemap_comps} \
 proc ::RosettaInputGenerator::make_abscript_mover {name cycles fraglist} \
 {
 	set out ""
-	append out "<AbscriptMover name=\"$name\" cycles=\"$cycles\" >\n"
+	append out "<AbscriptMover name=$name cycles=$cycles >\n"
 	foreach frag $fraglist {
 		set name [lindex $frag 0]
-		append out "<Fragments large_frags=\"[lindex $frag 0]\" small_frags=\"[lindex $frag 1]\" selector=\"[lindex $frag 2]\" /> \n"
+		append out "<Fragments large_frags=\"[lindex $frag 0]\" small_frags=\"[lindex $frag 1]\" selector=[lindex $frag 2] /> \n"
 	}
 	append out "</AbscriptMover> \n"
 	return $out
@@ -708,12 +708,12 @@ proc ::RosettaInputGenerator::make_abscript_mover {name cycles fraglist} \
 proc ::RosettaInputGenerator::make_environment {name autocut registerList applyList} \
 {
 	set out ""
-	append out "<Environment name=\"$name\" auto_cut=\"$autocut\"> \n"
+	append out "<Environment name=$name auto_cut=$autocut> \n"
 	foreach reg $registerList {
-		append out "<Register mover=\"$reg\" />\n"
+		append out "<Register mover=$reg />\n"
 	}
 	foreach app $applyList {
-		append out "<Apply mover=\"$app\" />\n"
+		append out "<Apply mover=$app />\n"
 	}
 	append out "</Environment>\n"
 	return $out
@@ -724,13 +724,13 @@ proc ::RosettaInputGenerator::make_environment {name autocut registerList applyL
 proc ::RosettaInputGenerator::make_rigid_chunk {name regselector template selector apply_to_template} \
 {
 	global tempPath
-	set out "<RigidChunkCM name=\"$name\" region_selector=\"$regselector\" template=\"$tempPath/$template\" selector=\"$selector\" apply_to_template=\"$apply_to_template\" />\n"
+	set out "<RigidChunkCM name=$name region_selector=$regselector template=\"$tempPath/$template\" selector=$selector apply_to_template=$apply_to_template />\n"
 	return $out
 }
 
 
-#<CartesianSampler name=cen5_50 automode_scorecut=-0.5 scorefxn=cen mcscorefxn=cen
-#fascorefxn=dens_soft strategy="auto" fragbias="density" rms=%%rms%% ncycles=200 fullatom=0
+#<CartesianSampler name=cen5_50 automode_scorecut=-0.5 scorefxn=cen mcscorefxn=cen 
+#fascorefxn=dens_soft strategy="auto" fragbias="density" rms=%%rms%% ncycles=200 fullatom=0 
 #bbmove=0 nminsteps=25 temp=4 fraglens=7 nfrags=25 residues_to_exclude="50-116"/>
 # usage
 
@@ -741,9 +741,9 @@ proc ::RosettaInputGenerator::make_cart_sample {arg} \
 		::RosettaInputGenerator::wrong_input
 	}
 	if {[llength $arg] == 16} {
-		append out "<CartesianSampler name=\"[lindex $arg 0]\" automode_scorecut=\"[lindex $arg 1]\" scorefxn=\"[lindex $arg 2]\" mcscorefxn=\"[lindex $arg 3]\" fascorefxn=\"[lindex $arg 4]\" strategy=\"[lindex $arg 5]\" fragbias=\"[lindex $arg 6]\" rms=\"[lindex $arg 7]\" ncycles=\"[lindex $arg 8]\" fullatom=\"[lindex $arg 9]\" bbmove=\"[lindex $arg 10]\" nminsteps=\"[lindex $arg 11]\" temp=\"[lindex $arg 12]\" fraglens=\"[lindex $arg 13]\" nfrags=\"[lindex $arg 14]\" residues_to_exclude=\"[lindex $arg 15]\" />"
+		append out "<CartesianSampler name=[lindex $arg 0] automode_scorecut=[lindex $arg 1] scorefxn=[lindex $arg 2] mcscorefxn=[lindex $arg 3] fascorefxn=[lindex $arg 4] strategy=[lindex $arg 5] fragbias=[lindex $arg 6] rms=[lindex $arg 7] ncycles=[lindex $arg 8] fullatom=[lindex $arg 9] bbmove=[lindex $arg 10] nminsteps=[lindex $arg 11] temp=[lindex $arg 12] fraglens=[lindex $arg 13] nfrags=[lindex $arg 14] residues_to_exclude=\"[lindex $arg 15]\" />"
 	} else {
-		append out "<CartesianSampler name=\"[lindex $arg 0]\" automode_scorecut=\"[lindex $arg 1]\" scorefxn=\"[lindex $arg 2]\" mcscorefxn=\"[lindex $arg 3]\" fascorefxn=\"[lindex $arg 4]\" strategy=\"[lindex $arg 5]\" fragbias=\"[lindex $arg 6]\" rms=\"[lindex $arg 7]\" ncycles=\"[lindex $arg 8]\" fullatom=\"[lindex $arg 9]\" bbmove=\"[lindex $arg 10]\" nminsteps=\"[lindex $arg 11]\" temp=\"[lindex $arg 12]\" fraglens=\"[lindex $arg 13]\" nfrags=\"[lindex $arg 14]\" />"
+		append out "<CartesianSampler name=[lindex $arg 0] automode_scorecut=[lindex $arg 1] scorefxn=[lindex $arg 2] mcscorefxn=[lindex $arg 3] fascorefxn=[lindex $arg 4] strategy=[lindex $arg 5] fragbias=[lindex $arg 6] rms=[lindex $arg 7] ncycles=[lindex $arg 8] fullatom=[lindex $arg 9] bbmove=[lindex $arg 10] nminsteps=[lindex $arg 11] temp=[lindex $arg 12] fraglens=[lindex $arg 13] nfrags=[lindex $arg 14] />"
 	}
 	append out "\n"
 	return $out
@@ -760,7 +760,7 @@ proc ::RosettaInputGenerator::make_cart_sample {arg} \
 proc ::RosettaInputGenerator::make_relaxcart {name repeats movemap_comps} \
 {
 	set out ""
-	append out "<FastRelax name=\"$name\" scorefxn=\"dens\" repeats=\"$repeats\" cartesian=\"1\"> \n"
+	append out "<FastRelax name=$name scorefxn=dens repeats=$repeats cartesian=1> \n"
 	append out [::RosettaInputGenerator::make_movemap $movemap_comps]
 	append out "</FastRelax> \n"
 	return $out
@@ -770,14 +770,14 @@ proc ::RosettaInputGenerator::make_relaxcart {name repeats movemap_comps} \
 #<MinMover name=cenmin scorefxn=cen type=lbfgs_armijo_nonmonotone max_iter=200 tolerance=0.00001 chi=0 bb=0>
 #			<MoveMap>
 #				<Chain number=1 chi=0 bb=0 />
-#				<Span begin=1 end=61 chi=1 bb=1 />
+#				<Span begin=1 end=61 chi=1 bb=1 /> 
 #			</MoveMap>
 #		</MinMover>
 
 proc ::RosettaInputGenerator::make_cenmin {name chi bb movemap_comps} \
 {
 	set out ""
-	append out "<MinMover name=\"$name\" scorefxn=\"cen\" type=\"lbfgs_armijo_nonmonotone\" max_iter=\"200\" tolerance=\"0.00001\" chi=\"$chi\" bb=\"$bb\"> \n"
+	append out "<MinMover name=$name scorefxn=cen type=lbfgs_armijo_nonmonotone max_iter=200 tolerance=0.00001 chi=$chi bb=$bb> \n"
 	append out [::RosettaInputGenerator::make_movemap $movemap_comps]
 	append out "</MinMover>\n"
 	return $out
@@ -794,10 +794,10 @@ proc ::RosettaInputGenerator::make_resid_selectors {components} \
 		set name [lindex $comp 0]
 		switch -exact -- $name {
 			"Index" {
-				append out "<Index name=\"[lindex $comp 1]\" resnums=\"[lindex $comp 2]\" />\n"
+				append out "<Index name=[lindex $comp 1] resnums=\"[lindex $comp 2]\" />\n"
 			}
 			"Chain" {
-				append out "<Chain name=\"[lindex $comp 1]\" chains=\"[lindex $comp 2]\" /> \n"
+				append out "<Chain name=[lindex $comp 1] chains=\"[lindex $comp 2]\" /> \n"
 			}
 			default {
 				::RosettaInputGenerator::wrong_input
@@ -813,7 +813,7 @@ proc ::RosettaInputGenerator::make_protocol {movernames} \
 	set out ""
 	append out "<PROTOCOLS> \n"
 	foreach mover $movernames {
-		append out "<Add mover=\"$mover\"/> \n"
+		append out "<Add mover=$mover/> \n"
 	}
 	append out "</PROTOCOLS> \n"
 	return $out
@@ -826,15 +826,15 @@ proc ::RosettaInputGenerator::make_default_scfxn {} \
 {
 	return "<SCOREFXNS>
 		<cen weights=\"score4_smooth_cart\">
-			<Reweight scoretype=\"elec_dens_fast weight=20\"/>
+			<Reweight scoretype=elec_dens_fast weight=20/>
 		</cen>
 		<dens_soft weights=\"soft_rep\">
-			<Reweight scoretype=\"cart_bonded\" weight=\"0.5\"/>
-			<Reweight scoretype=\"pro_close\" weight=\"0.0\"/>
-			<Reweight scoretype=\"elec_dens_fast\" weight=\"%%denswt%%\"/>
+			<Reweight scoretype=cart_bonded weight=0.5/>
+			<Reweight scoretype=pro_close weight=0.0/>
+			<Reweight scoretype=elec_dens_fast weight=\"%%denswt%%\"/>
 		</dens_soft>
 		<dens weights=\"talaris2013_cart\">
-			<Reweight scoretype=\"elec_dens_fast\" weight=\"%%denswt%%\"/>
+			<Reweight scoretype=elec_dens_fast weight=\"%%denswt%%\"/>
 			<Set scale_sc_dens_byres=\"R:0.76,K:0.76,E:0.76,D:0.76,M:0.76,C:0.81,Q:0.81,H:0.81,N:0.81,T:0.81,S:0.81,Y:0.88,W:0.88,A:0.88,F:0.88,P:0.88,I:0.88,L:0.88,V:0.88\"/>
 		</dens>
 	</SCOREFXNS> \n"
@@ -844,7 +844,7 @@ proc ::RosettaInputGenerator::make_default_scfxn {} \
 
 proc ::RosettaInputGenerator::make_density_setup {} \
 {
-	return "<SetupForDensityScoring name=\"setupdens\"/> \n <LoadDensityMap name=\"loaddens\" mapfile=\"%%map%%\"/>\n"
+	return "<SetupForDensityScoring name=setupdens/> \n <LoadDensityMap name=loaddens mapfile=\"%%map%%\"/>\n"
 }
 
 
@@ -891,7 +891,7 @@ if \[ -z \"\$1\" \]\; then
   echo Need job name!
   exit
 fi
-/home/sgeadmin/bin/linux-x64/qsub -q linux -N \$JOBNAME -j y -o \${PATH}/OUTPUT_FILES << EOF
+/home/sgeadmin/bin/linux-x64/qsub -q linux -N \$JOBNAME -j y -o \${PATH}/OUTPUT_FILES << EOF  
 #\$ -S /bin/bash
 #\$ -t 1-$tasks
 for i in {1..$nPerTask}
@@ -912,7 +912,7 @@ $rosettapath/rosetta_scripts.$platform \\
         -overwrite \\
         -ignore_zero_occupancy false \\
 	-seed_offset \\\$idx
-
+         
 mv \${JOBNAME}*.pdb ./pdb_out/
 mv *.sc ./sc_out/
 done
@@ -995,10 +995,10 @@ $rosettapath/minirosetta.$platform \\
 	-nstruct $nstruct \\
 	-overwrite
 
-#mkdir intermediates
-#mv loops_closed*.pdb ./intermediates/
-#mv *.sc ./sc_out/
-#mv $jobname*.pdb ./pdb_out/
+mkdir intermediates
+mv loops_closed*.pdb ./intermediates/
+mv *.sc ./sc_out/
+mv $jobname*.pdb ./pdb_out/
 
 "
 }
@@ -1014,7 +1014,7 @@ proc ::RosettaInputGenerator::make_insertion_cluster_script {jobname mol nstruct
 export PATH=\$(pwd)
 JOBNAME=$jobname
 
-/home/sgeadmin/bin/linux-x64/qsub -q linux -N \$JOBNAME -j y -o \${PATH}/OUTPUT_FILES << EOF
+/home/sgeadmin/bin/linux-x64/qsub -q linux -N \$JOBNAME -j y -o \${PATH}/OUTPUT_FILES << EOF  
 #\$ -S /bin/bash
 #\$ -t 1-$tasks
 for i in {1..$nPerTask}
@@ -1095,8 +1095,8 @@ $rosettapath/rosetta_scripts.$platform \\
     -ignore_zero_occupancy false\\
     -overwrite
 
-#mv \${JOBNAME}*.pdb ./pdb_out/
-#mv *.sc ./sc_out/
+mv \${JOBNAME}*.pdb ./pdb_out/
+mv *.sc ./sc_out/
 
 "
 }
@@ -1114,7 +1114,7 @@ if \[ -z \"\$1\" \]\; then
   echo Need job name!
   exit
 fi
-/home/sgeadmin/bin/linux-x64/qsub -q linux -N \$JOBNAME -j y -o \${PATH}/OUTPUT_FILES << EOF
+/home/sgeadmin/bin/linux-x64/qsub -q linux -N \$JOBNAME -j y -o \${PATH}/OUTPUT_FILES << EOF  
 #\$ -S /bin/bash
 #\$ -t 1-$tasks
 for i in {1..$nPerTask}
@@ -1133,7 +1133,7 @@ $rosettapath/rosetta_scripts.linuxgccrelease \\
         -overwrite \\
         -ignore_zero_occupancy false \\
 	-seed_offset \\\$idx
-
+         
 mv \${JOBNAME}*.pdb ./pdb_out/
 mv *.sc ./sc_out/
 done
@@ -1147,12 +1147,12 @@ EOF
 
 proc ::RosettaInputGenerator::make_centroid_mover {name} \
 {
-	return "<SwitchResidueTypeSetMover name=\"$name\" set=\"centroid\" /> \n"
+	return "<SwitchResidueTypeSetMover name=$name set=\"centroid\" /> \n"
 }
 
 proc ::RosettaInputGenerator::make_full_atom_mover {name} \
 {
-	return "<SwitchResidueTypeSetMover name=\"$name\" set=\"fa_standard\" />\n"
+	return "<SwitchResidueTypeSetMover name=$name set=\"fa_standard\" />\n"
 }
 
 # /Scr/scr-test-trudack/marc1/rosetta_bin_linux_2015.12.57698_bundle/main/source/bin/rosetta_scripts.linuxgccrelease

--- a/rosetta_input_generator.tcl
+++ b/rosetta_input_generator.tcl
@@ -14,13 +14,13 @@
 
 namespace eval ::RosettaInputGenerator {
     namespace export refine_with_rosetta
-    namespace export refine_sidechains_rosetta
+    # namespace export refine_sidechains_rosetta
     namespace export rosetta_abinitio
-    
+
 	# Set up Variable
 	set version 0.1
 	set packageDescription "RosettaInputGenerator Plugin"
- 
+
     # Variable for the path of the script
     variable home [file join [pwd] [file dirname [info script]]]
 }
@@ -31,10 +31,10 @@ proc refine_with_rosetta {args} \
 	return [eval ::RosettaInputGenerator::refine_with_rosetta $args]
 }
 
-proc refine_sidechains_rosetta {args} \
-{
-	return [eval ::RosettaInputGenerator::refine_sidechains_rosetta $args]
-}
+#proc refine_sidechains_rosetta {args} \
+#{
+#	return [eval ::RosettaInputGenerator::refine_sidechains_rosetta $args]
+#}
 
 proc rosetta_abinitio {args} \
 {
@@ -110,7 +110,7 @@ proc ::RosettaInputGenerator::refine_with_rosetta {jobname MOL mapname res score
 		set cart [::RosettaInputGenerator::make_cart_sample [list cen5_50 $score_dens cen cen dens_soft auto density %%rms%% 200 0 0 25 4 7 25 "$exclude"]]
 		append tot $cart
 	}
-	
+
 	# append tot [::RosettaInputGenerator::make_full_atom_mover "fullatom"]
 
 	# set fr [::RosettaInputGenerator::make_fastrelax relax 1 [list {"Chain" 1 0 0}]]
@@ -119,7 +119,7 @@ proc ::RosettaInputGenerator::refine_with_rosetta {jobname MOL mapname res score
 	set cst [::RosettaInputGenerator::make_coord_cst [list coordcst 20 CA $anchor_residue 0] $conv_anchor_spans]
 	append tot $cst
 
-# "centroid" , "coordcst" "cenmin" 
+# "centroid" , "coordcst" "cenmin"
 	lappend allMovers "setupdens" "loaddens" "coordcst" "relaxcart";#
 	if {$cartesianSampler} {
 		lappend allMovers "coordcst" "cen5_50" "coordcst" "relaxcart";
@@ -158,7 +158,7 @@ proc ::RosettaInputGenerator::refine_with_rosetta {jobname MOL mapname res score
 		puts "Preparing $nstruct structures on cluster. $tasks tasks with $nPerTask structures each."
 		set bashscript [::RosettaInputGenerator::make_cluster_script 25 1.5 $res $mapname.mrc $jobname $nstruct $tasks $nPerTask]
 	}
-	
+
 
 	set script [open "$jobname.sh" w]
 	puts $script $bashscript
@@ -225,7 +225,7 @@ proc ::RosettaInputGenerator::rosetta_basic_refinement {jobname MOL nstruct clus
 		# set cart [::RosettaInputGenerator::make_cart_sample [list cen5_50 $score_dens cen cen dens_soft auto density %%rms%% 200 0 0 25 4 7 25 "$exclude"]]
 		# append tot $cart
 	# }
-	
+
 	# append tot [::RosettaInputGenerator::make_full_atom_mover "fullatom"]
 
 	# set fr [::RosettaInputGenerator::make_fastrelax relax 1 [list {"Chain" 1 0 0}]]
@@ -237,7 +237,7 @@ proc ::RosettaInputGenerator::rosetta_basic_refinement {jobname MOL nstruct clus
 	set fr [make_fastrelax relax 1 $converted]
 	append tot $fr
 
-# "centroid" , "coordcst" "cenmin" 
+# "centroid" , "coordcst" "cenmin"
 	lappend allMovers "coordcst" "relax";#
 
 	append tot "</MOVERS>\n"
@@ -275,7 +275,7 @@ proc ::RosettaInputGenerator::rosetta_basic_refinement {jobname MOL nstruct clus
 		# puts "Preparing $nstruct structures on cluster. $tasks tasks with $nPerTask structures each."
 		# set bashscript [::RosettaInputGenerator::make_cluster_script 25 1.5 $res $mapname.mrc $jobname $nstruct $tasks $nPerTask]
 	}
-	
+
 
 	set script [open "$jobname.sh" w]
 	puts $script $bashscript
@@ -383,7 +383,7 @@ proc ::RosettaInputGenerator::rosetta_basic_refinement {jobname MOL nstruct clus
 # 		puts "Preparing $nstruct structures on cluster. $tasks tasks with $nPerTask structures each."
 # 		set bashscript [make_cluster_script 25 1.5 $res $mapname.mrc $jobname $nstruct $tasks $nPerTask]
 # 	}
-	
+
 
 # 	set script [open "$jobname.sh" w]
 # 	puts $script $bashscript
@@ -430,7 +430,7 @@ proc ::RosettaInputGenerator::rosetta_abinitio {jobname MOL fragfiles fragpath n
 
 	#LOAD SCRFXNS
 	#puts [make_default_scfxn]
-	
+
 	#append tot [make_default_scfxn]
 
 	#RESIDUE SELECTORS
@@ -477,16 +477,16 @@ proc ::RosettaInputGenerator::rosetta_abinitio {jobname MOL fragfiles fragpath n
 
 	#lappend allMovers "coordcst"
 
-	
+
 	#lappend allMovers "relax"
 
-	
+
 	#lappend allMovers "cen5_50"
 
-	
+
 	#lappend allMovers "relaxcart"
 
-	
+
 	#lappend allMovers "cenmin"
 
 	append tot "</MOVERS>\n"
@@ -524,7 +524,7 @@ proc ::RosettaInputGenerator::rosetta_abinitio {jobname MOL fragfiles fragpath n
 	} elseif {!$test && !$cluster} {
 		set bashscript [make_abinitio_local_script $jobname $nstruct]
 	}
-	
+
 
 	set script [open "$jobname.sh" w]
 	puts $script $bashscript
@@ -595,14 +595,14 @@ proc ::RosettaInputGenerator::rosetta_insertion {jobname MOL fragfiles fasta fra
 
 }
 
-#<CartesianSampler name=cen5_50 automode_scorecut=-0.5 scorefxn=cen mcscorefxn=cen 
-#fascorefxn=dens_soft strategy="auto" fragbias="density" rms=%%rms%% ncycles=200 fullatom=0 
+#<CartesianSampler name=cen5_50 automode_scorecut=-0.5 scorefxn=cen mcscorefxn=cen
+#fascorefxn=dens_soft strategy="auto" fragbias="density" rms=%%rms%% ncycles=200 fullatom=0
 #bbmove=0 nminsteps=25 temp=4 fraglens=7 nfrags=25 residues_to_exclude="50-116"/>
 # usage
 
 
 #<Chain number=1 chi=0 bb=0 />
-#<Span begin=1 end=61 chi=1 bb=1 /> 
+#<Span begin=1 end=61 chi=1 bb=1 />
 # <Jump number=1 setting=0/>
 # each component has to be like:
 #
@@ -620,19 +620,19 @@ proc ::RosettaInputGenerator::make_movemap {components} \
 				if {[llength $comp] != 4} {
 					wrong_input "chain length"
 				}
-				append out "<Chain number=[lindex $comp 1] chi=[lindex $comp 2] bb=[lindex $comp 3] /> \n"
+				append out "<Chain number=\"[lindex $comp 1]\" chi=\"[lindex $comp 2]\" bb=\"[lindex $comp 3]\" /> \n"
 			}
 			"Span" {
 				if {[llength $comp] != 5} {
 					wrong_input "span length"
 				}
-				append out "<Span begin=[lindex $comp 1] end=[lindex $comp 2] chi=[lindex $comp 3] bb=[lindex $comp 4] /> \n"
+				append out "<Span begin=\"[lindex $comp 1]\" end=\"[lindex $comp 2]\" chi=\"[lindex $comp 3]\" bb=\"[lindex $comp 4]\" /> \n"
 			}
 			"Jump" {
 				if {[llength $comp] != 3} {
 					wrong_input
 				}
-				append out "<Jump number=[lindex $comp 1] setting=[lindex $comp 2] /> \n"
+				append out "<Jump number=\"[lindex $comp 1]\" setting=\"[lindex $comp 2]\" /> \n"
 			}
 			default {
 				::RosettaInputGenerator::wrong_input
@@ -643,7 +643,7 @@ proc ::RosettaInputGenerator::make_movemap {components} \
 	return $out
 }
 
-#<CoordinateCst name=coordcst stddev=20 atom=CA anchor_res=90 jump=0  > 
+#<CoordinateCst name=coordcst stddev=20 atom=CA anchor_res=90 jump=0  >
 #<Span begin=66 end=104 />
 #</CoordinateCst>
 # usage:
@@ -655,12 +655,12 @@ proc ::RosettaInputGenerator::make_coord_cst {config spans} \
 	if {[llength $config] != 5} {
 		::RosettaInputGenerator::wrong_input
 	}
-	append out "<CoordinateCst name=[lindex $config 0] stddev=[lindex $config 1] atom=[lindex $config 2] anchor_res=[lindex $config 3] jump=[lindex $config 4]> \n"
+	append out "<CoordinateCst name=\"[lindex $config 0]\" stddev=\"[lindex $config 1]\" atom=\"[lindex $config 2]\" anchor_res=\"[lindex $config 3]\" jump=\"[lindex $config 4]\"> \n"
 	foreach span $spans {
 		if {[llength $span] != 2} {
 			::RosettaInputGenerator::wrong_input
 		}
-		append out "<Span begin=[lindex $span 0] end=[lindex $span 1] /> \n"
+		append out "<Span begin=\"[lindex $span 0]\" end=\"[lindex $span 1]\" /> \n"
 	}
 	append out "</CoordinateCst> \n"
 	return $out
@@ -675,7 +675,7 @@ proc ::RosettaInputGenerator::make_coord_cst {config spans} \
 proc ::RosettaInputGenerator::make_fastrelax {name repeats movemap_comps} \
 {
 	set out ""
-	append out "<FastRelax name=$name repeats=$repeats>\n"
+	append out "<FastRelax name=\"$name\" repeats=\"$repeats\">\n"
 	append out [::RosettaInputGenerator::make_movemap $movemap_comps]
 	append out "</FastRelax>\n"
 	return $out
@@ -691,10 +691,10 @@ proc ::RosettaInputGenerator::make_fastrelax {name repeats movemap_comps} \
 proc ::RosettaInputGenerator::make_abscript_mover {name cycles fraglist} \
 {
 	set out ""
-	append out "<AbscriptMover name=$name cycles=$cycles >\n"
+	append out "<AbscriptMover name=\"$name\" cycles=\"$cycles\" >\n"
 	foreach frag $fraglist {
 		set name [lindex $frag 0]
-		append out "<Fragments large_frags=\"[lindex $frag 0]\" small_frags=\"[lindex $frag 1]\" selector=[lindex $frag 2] /> \n"
+		append out "<Fragments large_frags=\"[lindex $frag 0]\" small_frags=\"[lindex $frag 1]\" selector=\"[lindex $frag 2]\" /> \n"
 	}
 	append out "</AbscriptMover> \n"
 	return $out
@@ -708,12 +708,12 @@ proc ::RosettaInputGenerator::make_abscript_mover {name cycles fraglist} \
 proc ::RosettaInputGenerator::make_environment {name autocut registerList applyList} \
 {
 	set out ""
-	append out "<Environment name=$name auto_cut=$autocut> \n"
+	append out "<Environment name=\"$name\" auto_cut=\"$autocut\"> \n"
 	foreach reg $registerList {
-		append out "<Register mover=$reg />\n"
+		append out "<Register mover=\"$reg\" />\n"
 	}
 	foreach app $applyList {
-		append out "<Apply mover=$app />\n"
+		append out "<Apply mover=\"$app\" />\n"
 	}
 	append out "</Environment>\n"
 	return $out
@@ -724,13 +724,13 @@ proc ::RosettaInputGenerator::make_environment {name autocut registerList applyL
 proc ::RosettaInputGenerator::make_rigid_chunk {name regselector template selector apply_to_template} \
 {
 	global tempPath
-	set out "<RigidChunkCM name=$name region_selector=$regselector template=\"$tempPath/$template\" selector=$selector apply_to_template=$apply_to_template />\n"
+	set out "<RigidChunkCM name=\"$name\" region_selector=\"$regselector\" template=\"$tempPath/$template\" selector=\"$selector\" apply_to_template=\"$apply_to_template\" />\n"
 	return $out
 }
 
 
-#<CartesianSampler name=cen5_50 automode_scorecut=-0.5 scorefxn=cen mcscorefxn=cen 
-#fascorefxn=dens_soft strategy="auto" fragbias="density" rms=%%rms%% ncycles=200 fullatom=0 
+#<CartesianSampler name=cen5_50 automode_scorecut=-0.5 scorefxn=cen mcscorefxn=cen
+#fascorefxn=dens_soft strategy="auto" fragbias="density" rms=%%rms%% ncycles=200 fullatom=0
 #bbmove=0 nminsteps=25 temp=4 fraglens=7 nfrags=25 residues_to_exclude="50-116"/>
 # usage
 
@@ -741,9 +741,9 @@ proc ::RosettaInputGenerator::make_cart_sample {arg} \
 		::RosettaInputGenerator::wrong_input
 	}
 	if {[llength $arg] == 16} {
-		append out "<CartesianSampler name=[lindex $arg 0] automode_scorecut=[lindex $arg 1] scorefxn=[lindex $arg 2] mcscorefxn=[lindex $arg 3] fascorefxn=[lindex $arg 4] strategy=[lindex $arg 5] fragbias=[lindex $arg 6] rms=[lindex $arg 7] ncycles=[lindex $arg 8] fullatom=[lindex $arg 9] bbmove=[lindex $arg 10] nminsteps=[lindex $arg 11] temp=[lindex $arg 12] fraglens=[lindex $arg 13] nfrags=[lindex $arg 14] residues_to_exclude=\"[lindex $arg 15]\" />"
+		append out "<CartesianSampler name=\"[lindex $arg 0]\" automode_scorecut=\"[lindex $arg 1]\" scorefxn=\"[lindex $arg 2]\" mcscorefxn=\"[lindex $arg 3]\" fascorefxn=\"[lindex $arg 4]\" strategy=\"[lindex $arg 5]\" fragbias=\"[lindex $arg 6]\" rms=\"[lindex $arg 7]\" ncycles=\"[lindex $arg 8]\" fullatom=\"[lindex $arg 9]\" bbmove=\"[lindex $arg 10]\" nminsteps=\"[lindex $arg 11]\" temp=\"[lindex $arg 12]\" fraglens=\"[lindex $arg 13]\" nfrags=\"[lindex $arg 14]\" residues_to_exclude=\"[lindex $arg 15]\" />"
 	} else {
-		append out "<CartesianSampler name=[lindex $arg 0] automode_scorecut=[lindex $arg 1] scorefxn=[lindex $arg 2] mcscorefxn=[lindex $arg 3] fascorefxn=[lindex $arg 4] strategy=[lindex $arg 5] fragbias=[lindex $arg 6] rms=[lindex $arg 7] ncycles=[lindex $arg 8] fullatom=[lindex $arg 9] bbmove=[lindex $arg 10] nminsteps=[lindex $arg 11] temp=[lindex $arg 12] fraglens=[lindex $arg 13] nfrags=[lindex $arg 14] />"
+		append out "<CartesianSampler name=\"[lindex $arg 0]\" automode_scorecut=\"[lindex $arg 1]\" scorefxn=\"[lindex $arg 2]\" mcscorefxn=\"[lindex $arg 3]\" fascorefxn=\"[lindex $arg 4]\" strategy=\"[lindex $arg 5]\" fragbias=\"[lindex $arg 6]\" rms=\"[lindex $arg 7]\" ncycles=\"[lindex $arg 8]\" fullatom=\"[lindex $arg 9]\" bbmove=\"[lindex $arg 10]\" nminsteps=\"[lindex $arg 11]\" temp=\"[lindex $arg 12]\" fraglens=\"[lindex $arg 13]\" nfrags=\"[lindex $arg 14]\" />"
 	}
 	append out "\n"
 	return $out
@@ -760,7 +760,7 @@ proc ::RosettaInputGenerator::make_cart_sample {arg} \
 proc ::RosettaInputGenerator::make_relaxcart {name repeats movemap_comps} \
 {
 	set out ""
-	append out "<FastRelax name=$name scorefxn=dens repeats=$repeats cartesian=1> \n"
+	append out "<FastRelax name=\"$name\" scorefxn=\"dens\" repeats=\"$repeats\" cartesian=\"1\"> \n"
 	append out [::RosettaInputGenerator::make_movemap $movemap_comps]
 	append out "</FastRelax> \n"
 	return $out
@@ -770,14 +770,14 @@ proc ::RosettaInputGenerator::make_relaxcart {name repeats movemap_comps} \
 #<MinMover name=cenmin scorefxn=cen type=lbfgs_armijo_nonmonotone max_iter=200 tolerance=0.00001 chi=0 bb=0>
 #			<MoveMap>
 #				<Chain number=1 chi=0 bb=0 />
-#				<Span begin=1 end=61 chi=1 bb=1 /> 
+#				<Span begin=1 end=61 chi=1 bb=1 />
 #			</MoveMap>
 #		</MinMover>
 
 proc ::RosettaInputGenerator::make_cenmin {name chi bb movemap_comps} \
 {
 	set out ""
-	append out "<MinMover name=$name scorefxn=cen type=lbfgs_armijo_nonmonotone max_iter=200 tolerance=0.00001 chi=$chi bb=$bb> \n"
+	append out "<MinMover name=\"$name\" scorefxn=\"cen\" type=\"lbfgs_armijo_nonmonotone\" max_iter=\"200\" tolerance=\"0.00001\" chi=\"$chi\" bb=\"$bb\"> \n"
 	append out [::RosettaInputGenerator::make_movemap $movemap_comps]
 	append out "</MinMover>\n"
 	return $out
@@ -794,10 +794,10 @@ proc ::RosettaInputGenerator::make_resid_selectors {components} \
 		set name [lindex $comp 0]
 		switch -exact -- $name {
 			"Index" {
-				append out "<Index name=[lindex $comp 1] resnums=\"[lindex $comp 2]\" />\n"
+				append out "<Index name=\"[lindex $comp 1]\" resnums=\"[lindex $comp 2]\" />\n"
 			}
 			"Chain" {
-				append out "<Chain name=[lindex $comp 1] chains=\"[lindex $comp 2]\" /> \n"
+				append out "<Chain name=\"[lindex $comp 1]\" chains=\"[lindex $comp 2]\" /> \n"
 			}
 			default {
 				::RosettaInputGenerator::wrong_input
@@ -813,7 +813,7 @@ proc ::RosettaInputGenerator::make_protocol {movernames} \
 	set out ""
 	append out "<PROTOCOLS> \n"
 	foreach mover $movernames {
-		append out "<Add mover=$mover/> \n"
+		append out "<Add mover=\"$mover\"/> \n"
 	}
 	append out "</PROTOCOLS> \n"
 	return $out
@@ -826,15 +826,15 @@ proc ::RosettaInputGenerator::make_default_scfxn {} \
 {
 	return "<SCOREFXNS>
 		<cen weights=\"score4_smooth_cart\">
-			<Reweight scoretype=elec_dens_fast weight=20/>
+			<Reweight scoretype=\"elec_dens_fast weight=20\"/>
 		</cen>
 		<dens_soft weights=\"soft_rep\">
-			<Reweight scoretype=cart_bonded weight=0.5/>
-			<Reweight scoretype=pro_close weight=0.0/>
-			<Reweight scoretype=elec_dens_fast weight=\"%%denswt%%\"/>
+			<Reweight scoretype=\"cart_bonded\" weight=\"0.5\"/>
+			<Reweight scoretype=\"pro_close\" weight=\"0.0\"/>
+			<Reweight scoretype=\"elec_dens_fast\" weight=\"%%denswt%%\"/>
 		</dens_soft>
 		<dens weights=\"talaris2013_cart\">
-			<Reweight scoretype=elec_dens_fast weight=\"%%denswt%%\"/>
+			<Reweight scoretype=\"elec_dens_fast\" weight=\"%%denswt%%\"/>
 			<Set scale_sc_dens_byres=\"R:0.76,K:0.76,E:0.76,D:0.76,M:0.76,C:0.81,Q:0.81,H:0.81,N:0.81,T:0.81,S:0.81,Y:0.88,W:0.88,A:0.88,F:0.88,P:0.88,I:0.88,L:0.88,V:0.88\"/>
 		</dens>
 	</SCOREFXNS> \n"
@@ -844,7 +844,7 @@ proc ::RosettaInputGenerator::make_default_scfxn {} \
 
 proc ::RosettaInputGenerator::make_density_setup {} \
 {
-	return "<SetupForDensityScoring name=setupdens/> \n <LoadDensityMap name=loaddens mapfile=\"%%map%%\"/>\n"
+	return "<SetupForDensityScoring name=\"setupdens\"/> \n <LoadDensityMap name=\"loaddens\" mapfile=\"%%map%%\"/>\n"
 }
 
 
@@ -891,7 +891,7 @@ if \[ -z \"\$1\" \]\; then
   echo Need job name!
   exit
 fi
-/home/sgeadmin/bin/linux-x64/qsub -q linux -N \$JOBNAME -j y -o \${PATH}/OUTPUT_FILES << EOF  
+/home/sgeadmin/bin/linux-x64/qsub -q linux -N \$JOBNAME -j y -o \${PATH}/OUTPUT_FILES << EOF
 #\$ -S /bin/bash
 #\$ -t 1-$tasks
 for i in {1..$nPerTask}
@@ -912,7 +912,7 @@ $rosettapath/rosetta_scripts.$platform \\
         -overwrite \\
         -ignore_zero_occupancy false \\
 	-seed_offset \\\$idx
-         
+
 mv \${JOBNAME}*.pdb ./pdb_out/
 mv *.sc ./sc_out/
 done
@@ -1014,7 +1014,7 @@ proc ::RosettaInputGenerator::make_insertion_cluster_script {jobname mol nstruct
 export PATH=\$(pwd)
 JOBNAME=$jobname
 
-/home/sgeadmin/bin/linux-x64/qsub -q linux -N \$JOBNAME -j y -o \${PATH}/OUTPUT_FILES << EOF  
+/home/sgeadmin/bin/linux-x64/qsub -q linux -N \$JOBNAME -j y -o \${PATH}/OUTPUT_FILES << EOF
 #\$ -S /bin/bash
 #\$ -t 1-$tasks
 for i in {1..$nPerTask}
@@ -1114,7 +1114,7 @@ if \[ -z \"\$1\" \]\; then
   echo Need job name!
   exit
 fi
-/home/sgeadmin/bin/linux-x64/qsub -q linux -N \$JOBNAME -j y -o \${PATH}/OUTPUT_FILES << EOF  
+/home/sgeadmin/bin/linux-x64/qsub -q linux -N \$JOBNAME -j y -o \${PATH}/OUTPUT_FILES << EOF
 #\$ -S /bin/bash
 #\$ -t 1-$tasks
 for i in {1..$nPerTask}
@@ -1133,7 +1133,7 @@ $rosettapath/rosetta_scripts.linuxgccrelease \\
         -overwrite \\
         -ignore_zero_occupancy false \\
 	-seed_offset \\\$idx
-         
+
 mv \${JOBNAME}*.pdb ./pdb_out/
 mv *.sc ./sc_out/
 done
@@ -1147,12 +1147,12 @@ EOF
 
 proc ::RosettaInputGenerator::make_centroid_mover {name} \
 {
-	return "<SwitchResidueTypeSetMover name=$name set=\"centroid\" /> \n"
+	return "<SwitchResidueTypeSetMover name=\"$name\" set=\"centroid\" /> \n"
 }
 
 proc ::RosettaInputGenerator::make_full_atom_mover {name} \
 {
-	return "<SwitchResidueTypeSetMover name=$name set=\"fa_standard\" />\n"
+	return "<SwitchResidueTypeSetMover name=\"$name\" set=\"fa_standard\" />\n"
 }
 
 # /Scr/scr-test-trudack/marc1/rosetta_bin_linux_2015.12.57698_bundle/main/source/bin/rosetta_scripts.linuxgccrelease

--- a/rosetta_scoring_wrapper.tcl
+++ b/rosetta_scoring_wrapper.tcl
@@ -58,11 +58,11 @@ proc ::RosettaScoring::score_refinement_cluster {run MOL max_structures} \
   }
 }
 
-proc ::RosettaScoring::score_abinitio {run MOL max_structures cluster} \
+proc ::RosettaScoring::score_abinitio {run MOL max_structures cluster {extra 0} args} \
 {
   puts $MOL
   if {$cluster} {
-    set pdb [::RosettaScoring::rosetta_scoring_cluster_consistent $max_structures $run]
+    set pdb [::RosettaScoring::rosetta_scoring_cluster_consistent $max_structures $run $extra]
     } else {
       set pdb [::RosettaScoring::rosetta_scoring $max_structures]
     }
@@ -209,12 +209,17 @@ proc ::RosettaScoring::rosetta_scoring_cluster {length_tot} {
 
 
 #package require Tcl 8.5
-proc ::RosettaScoring::rosetta_scoring_cluster_consistent {length_tot runname} {
+proc ::RosettaScoring::rosetta_scoring_cluster_consistent {length_tot runname {extra 0} args} {
   set file_list ""
   set val_list ""
   set id_list ""
   # set ic_val_list ""
-  set score_name "${runname}_score"
+  if {$extra == 0} {
+    set score_name "${runname}_score" 
+  } else {
+    set score_name "${runname}_${extra}_score"
+  }
+  puts $score_name
   set file_list [lsort -dictionary [glob ./sc_out/*.sc]]
   #set file_list [lsort -dictionary [glob ../rosetta_output_bbfix/sc_out/*.sc]]
   #set file_list [lsort -dictionary [glob ../rosetta_output_bbfree/sc_out/*.sc]]

--- a/rosetta_vmd.tcl
+++ b/rosetta_vmd.tcl
@@ -412,13 +412,13 @@ proc start_rosetta_insertion {jobname mol selections fragfiles fragpath fasta ns
 	exec mkdir -p pdb_out
 	exec mkdir -p OUTPUT_FILES
 	set output [exec "[pwd]/$jobname.sh" >> rosetta_log_$jobname.log &]
-	set current [exec ls -1v pdb_out | wc -l]
+	set current [llength [glob -nocomplain $jobname*.pdb ] ]
 	while {$current < $nstruct} {
 		set n 20
 		puts "Files are not yet available."
-		puts "Current number: [exec ls -1v pdb_out | wc -l] - [expr double($current)/($nstruct) * 100.0] %"
+		puts "Current number: $current - [expr double($current)/($nstruct) * 100.0] %"
 		after [expr {int($n * 1000)}]
-		set current [exec ls -1v pdb_out | wc -l]
+		set current [llength [glob -nocomplain $jobname*.pdb ] ]
 		if {$cluster} {
 			set logfile [open "rosetta_log_$jobname.log" r]
 			set dt [read $logfile]
@@ -433,6 +433,11 @@ proc start_rosetta_insertion {jobname mol selections fragfiles fragpath fasta ns
 			}
 		}	
 	}
+  file mkdir intermediates	
+	file rename {*}[glob loops_closed*.pdb] intermediates/
+  file rename {*}[glob *.sc] sc_out/
+	file rename {*}[glob *.pdb] pdb_out/
+
 	puts $output
 	puts "Rosetta insertion folding finished."
 	cd ..	

--- a/rosetta_vmd.tcl
+++ b/rosetta_vmd.tcl
@@ -351,13 +351,13 @@ proc start_rosetta_abinitio {jobname mol selections anchor fragfiles fragpath ns
 	exec mkdir -p pdb_out
 	exec mkdir -p OUTPUT_FILES
 	set output [exec "[pwd]/$jobname.sh" "$jobname" "$mol.pdb" >> rosetta_log_$jobname.log &]
-	set current [exec ls -1v pdb_out | wc -l]
+  set current [llength [glob -nocomplain *.pdb ] ]
 	while {$current < $nstruct} {
 		set n 5
 		puts "Files are not yet available."
-		puts "Current number: [exec ls -1v pdb_out | wc -l] - [expr double($current)/($nstruct) * 100.0] %"
+		puts "Current number: $current - [expr double($current)/($nstruct) * 100.0] %"
 		after [expr {int($n * 1000)}]
-		set current [exec ls -1v pdb_out | wc -l]
+		set current [llength [glob -nocomplain *.pdb ] ]
 		if {$cluster} {
 			set logfile [open "rosetta_log_$jobname.log" r]
 			set dt [read $logfile]
@@ -372,7 +372,10 @@ proc start_rosetta_abinitio {jobname mol selections anchor fragfiles fragpath ns
 			}
 		}	
 	}
-	puts $output
+	file rename {*}[glob *.sc] sc_out/
+	file rename {*}[glob *.pdb] pdb_out/
+	
+  puts $output
 	puts "Rosetta abinitio finished."
 	cd ..	
 }


### PR DESCRIPTION
I started working on the modelmaker wrapper a while back and then the tutorial package was updated later and I didn't realize it. The biggest issue was the _analyze_ command was not working correctly for insertion results, primarily because it was still trying to use Juan Perilla's cluster script.

The tutmm branch represents the latest code taken from the tutorial files merged with the _majority_ of the commits to github. This version has been tested to work with both examples in the README using Rosetta 3.8. In order to get everything to work, I had to reverse 2 of Max's changes.

1.  The 'robust find_selection' change was not working (it seemed to be cutting off too much of the residue number text).
2. The wildcard additions to the rosettaEXE variable. The wildcard was not getting processed correctly when running the insertion test case. Also, the use of the wildcard I was referring to was more encompassing, the idea being to remove the need to care about _any_ aspect of the OS you were on (i.e., it should be possible to call the rosetta commands you want by name and wildcard out _all_ of the 'macoslangrelease' or 'linuxgccrelease' identifiers. We can discuss this more elsewhere.

Max, please have a look at the diffs and also if possible, check out the tutmm branch and test it yourself. If everything appears okay, I will merge it back into master and we can continue working from there. Thanks!